### PR TITLE
feat(variants): add variant management components and services

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "pinia": "^3.0.3",
     "pinia-plugin-persistedstate": "^4.5.0",
     "vue": "^3.5.18",
-    "vue-router": "^4.5.1"
+    "vue-router": "^4.5.1",
+    "vue-sonner": "^2.0.9"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       vue-router:
         specifier: ^4.5.1
         version: 4.5.1(vue@3.5.21(typescript@5.8.3))
+      vue-sonner:
+        specifier: ^2.0.9
+        version: 2.0.9
     devDependencies:
       '@biomejs/biome':
         specifier: 2.2.2
@@ -1777,6 +1780,20 @@ packages:
     peerDependencies:
       vue: ^3.2.0
 
+  vue-sonner@2.0.9:
+    resolution: {integrity: sha512-i6BokNlNDL93fpzNxN/LZSn6D6MzlO+i3qXt6iVZne3x1k7R46d5HlFB4P8tYydhgqOrRbIZEsnRd3kG7qGXyw==}
+    peerDependencies:
+      '@nuxt/kit': ^4.0.3
+      '@nuxt/schema': ^4.0.3
+      nuxt: ^4.0.3
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
+      '@nuxt/schema':
+        optional: true
+      nuxt:
+        optional: true
+
   vue-tsc@3.0.6:
     resolution: {integrity: sha512-Tbs8Whd43R2e2nxez4WXPvvdjGbW24rOSgRhLOHXzWiT4pcP4G7KeWh0YCn18rF4bVwv7tggLLZ6MJnO6jXPBg==}
     hasBin: true
@@ -3472,6 +3489,8 @@ snapshots:
     dependencies:
       '@vue/devtools-api': 6.6.4
       vue: 3.5.21(typescript@5.8.3)
+
+  vue-sonner@2.0.9: {}
 
   vue-tsc@3.0.6(typescript@5.8.3):
     dependencies:

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
-import {RouterView, useRouter} from 'vue-router'
-import {useUserSessionStore} from "@/stores/user-session-store.ts";
-import {onMounted} from "vue";
+import { RouterView, useRouter } from 'vue-router'
+import { useUserSessionStore } from "@/stores/user-session-store.ts";
+import { onMounted } from "vue";
+import { Toaster } from 'vue-sonner';
 
 const router = useRouter()
 
 onMounted(() => {
   const userSession = useUserSessionStore();
-  const {logout, scheduleRefresh} = userSession;
+  const { logout, scheduleRefresh } = userSession;
 
   if (userSession.isAuthenticated) {
     scheduleRefresh();
@@ -20,6 +21,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <RouterView/>
+  <RouterView />
+  <Toaster position="top-right" :toast-options="{ duration: 4000 }" rich-colors close-button theme="system" expand
+    class="toast-container" />
 </template>
-

--- a/src/assets/style/root.css
+++ b/src/assets/style/root.css
@@ -4,3 +4,17 @@ body {
         display: grid;
     }
 }
+
+
+.toast-container {
+    z-index: 9999 !important;
+}
+
+dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5) !important;
+    z-index: 60 !important;
+}
+
+dialog {
+    z-index: 61 !important;
+}

--- a/src/components/layout/AddVariantTypeModal.vue
+++ b/src/components/layout/AddVariantTypeModal.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import FormInput from "../ui/FormInput.vue";
+import { VariantsTypeService } from "@/services/VariantsTypeService";
+import AppToast from "../ui/AppToast.vue";
+
+const variantTypeName = ref<string>("");
+const variantValueInput = ref<string>("");
+const variantValuesArray = ref<string[]>([]);
+const isLoading = ref<boolean>(false)
+const toastMessage = ref<string>("")
+const failedToAdd = ref<boolean>(false)
+
+const emit = defineEmits<{ variantChanged: [] }>();
+
+
+const addVariantValue = () => {
+    const trimmed = variantValueInput.value.trim();
+    if (trimmed && !variantValuesArray.value.includes(trimmed)) {
+        variantValuesArray.value.push(trimmed);
+    }
+    variantValueInput.value = "";
+};
+
+const handleKeydown = (e: KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === "," || e.key === "Tab") {
+        e.preventDefault();
+        addVariantValue();
+    }
+};
+
+const removeVariantValue = (value: string) => {
+    variantValuesArray.value = variantValuesArray.value.filter(v => v !== value);
+};
+
+const submitVariant = async (e: Event) => {
+    isLoading.value = true;
+    const formElement = e.target as HTMLFormElement;
+    if (variantValuesArray.value.length === 0) {
+        isLoading.value = false;
+        toastMessage.value = "Please add at least one variant value"
+        failedToAdd.value = true
+        return;
+    }
+    const variantData = {
+        name: formElement.variant_name.value,
+        values: variantValuesArray.value
+    };
+
+    const modal = document.getElementById("addVariantModal") as HTMLDialogElement
+
+    const addVariant = await VariantsTypeService.createVariantType(variantData.name, variantData.values);
+    console.log(addVariant);
+    if (addVariant[0].success) {
+        isLoading.value = false;
+        toastMessage.value = "Variant Type Added Successfully"
+        modal.close();
+        emit('variantChanged');
+    } else {
+        isLoading.value = false;
+        toastMessage.value = "Error Adding Variant Type"
+    }
+};
+</script>
+
+<template>
+    <dialog id="addVariantModal" class="modal">
+        <div class="modal-box w-full max-w-lg">
+            <h2 class="text-lg font-semibold uppercase mb-4">Add a new variant type</h2>
+            {{ variantTypeName }}
+            <form class="space-y-4" @submit.prevent="submitVariant">
+                <!-- Variant Name -->
+                <FormInput label="Variant Name" name="variant_name" type="text" kind="text"
+                    placeholder="Enter variant name" />
+
+                <!-- Variant Values Input -->
+                <div>
+                    <label class="block text-sm font-medium mb-1">Variant Type Values</label>
+                    <div
+                        class="flex flex-wrap items-center gap-2 p-2 border rounded-lg focus-within:ring-2 ring-primary/50">
+                        <!-- Pills -->
+                        <span v-for="(value, i) in variantValuesArray" :key="i"
+                            class="px-3 py-1 bg-primary/10 text-primary text-sm font-medium rounded-full flex items-center gap-2">
+                            {{ value }}
+                            <button type="button"
+                                class="text-primary hover:text-red-500 focus:outline-none cursor-pointer"
+                                @click="removeVariantValue(value)">
+                                ×
+                            </button>
+                        </span>
+
+                        <!-- Input -->
+                        <input v-model="variantValueInput" @keydown="handleKeydown" type="text"
+                            class="flex-1 outline-none p-1 bg-transparent text-sm"
+                            placeholder="Type and press Enter, Tab or comma" />
+                    </div>
+                </div>
+
+                <!-- Actions -->
+                <div class="modal-action mt-6 flex justify-end gap-3">
+                    <form method="dialog">
+                        <button class="btn btn-outline">Cancel</button>
+                    </form>
+                    <button type="submit" class="btn btn-primary" :disabled="isLoading">
+                        <span v-if="isLoading" class="loading loading-bars loading-md lg:loading-lg">
+                        </span>
+                        <span v-else>
+                            Add Variant Type
+                        </span>
+                    </button>
+                </div>
+            </form>
+        </div>
+
+        <!-- Click outside to close -->
+        <form method="dialog" class="modal-backdrop">
+            <button>Close</button>
+        </form>
+    </dialog>
+    <AppToast :message="toastMessage" :isError="failedToAdd" />
+</template>
+
+<style scoped>
+.modal-box {
+    animation: scaleIn 0.25s ease;
+}
+
+@keyframes scaleIn {
+    0% {
+        transform: scale(0.9);
+        opacity: 0;
+    }
+
+    100% {
+        transform: scale(1);
+        opacity: 1;
+    }
+}
+</style>

--- a/src/components/layout/AddVariantTypeModal.vue
+++ b/src/components/layout/AddVariantTypeModal.vue
@@ -2,14 +2,13 @@
 import { ref } from "vue";
 import FormInput from "../ui/FormInput.vue";
 import { VariantsTypeService } from "@/services/VariantsTypeService";
-import AppToast from "../ui/AppToast.vue";
+import { toast } from "vue-sonner";
+
 
 const variantTypeName = ref<string>("");
 const variantValueInput = ref<string>("");
 const variantValuesArray = ref<string[]>([]);
 const isLoading = ref<boolean>(false)
-const toastMessage = ref<string>("")
-const failedToAdd = ref<boolean>(false)
 
 const emit = defineEmits<{ variantChanged: [] }>();
 
@@ -38,8 +37,7 @@ const submitVariant = async (e: Event) => {
     const formElement = e.target as HTMLFormElement;
     if (variantValuesArray.value.length === 0) {
         isLoading.value = false;
-        toastMessage.value = "Please add at least one variant value"
-        failedToAdd.value = true
+        toast.error("Please add at least one variant value")
         return;
     }
     const variantData = {
@@ -53,12 +51,12 @@ const submitVariant = async (e: Event) => {
     console.log(addVariant);
     if (addVariant[0].success) {
         isLoading.value = false;
-        toastMessage.value = "Variant Type Added Successfully"
+        toast.success("Variant Type Added Successfully")
         modal.close();
         emit('variantChanged');
     } else {
         isLoading.value = false;
-        toastMessage.value = "Error Adding Variant Type"
+        toast.error("Error Adding Variant Type")
     }
 };
 </script>
@@ -117,7 +115,6 @@ const submitVariant = async (e: Event) => {
             <button>Close</button>
         </form>
     </dialog>
-    <AppToast :message="toastMessage" :isError="failedToAdd" />
 </template>
 
 <style scoped>

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -1,28 +1,25 @@
 <script setup lang="ts">
 
 import ThemeToggler from "@/components/ui/ThemeToggler.vue";
-import {Menu, Settings, Bell, User } from "lucide-vue-next";
-import {useSidebarStateStore} from "@/stores/sidebar-state-store.ts";
+import { Menu, Settings, Bell, User } from "lucide-vue-next";
+import { useSidebarStateStore } from "@/stores/sidebar-state-store.ts";
 import LogoutModal from "@/components/layout/LogoutModal.vue";
 import AppHeaderAvatar from "@/components/ui/AppHeaderAvatar.vue";
 
 const sidebarStore = useSidebarStateStore();
-const {open} = sidebarStore;
+const { open } = sidebarStore;
 </script>
 
 <template>
-  <header class="sticky top-0 bg-base-100 p-4 flex justify-between items-center gap-4">
-    <button
-        class="btn btn-circle btn-primary hover:text-white transition duration-200 md:hidden"
-        aria-label="Toggle Menu"
-        @click="open"
-    >
-      <Menu class="w-5 h-5"/>
+  <header class="sticky top-0 bg-base-100 p-4 flex z-20 justify-between items-center gap-4">
+    <button class="btn btn-circle btn-primary hover:text-white transition duration-200 md:hidden"
+      aria-label="Toggle Menu" @click="open">
+      <Menu class="w-5 h-5" />
     </button>
     <div class="flex-1 flex justify-end items-center gap-4 flex-wrap">
-      <ThemeToggler/>
-      <Settings/>
-      <Bell/>
+      <ThemeToggler />
+      <Settings />
+      <Bell />
       <AppHeaderAvatar />
     </div>
   </header>

--- a/src/components/ui/AppPagination.vue
+++ b/src/components/ui/AppPagination.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { StepBackIcon, StepForwardIcon } from "lucide-vue-next";
+import { computed } from "vue";
+
+interface PaginationMeta {
+    current_page: number;
+    last_page: number;
+    per_page?: number;
+    total?: number;
+}
+
+const props = defineProps<{
+    meta: PaginationMeta;
+    onPageChange: (page: number) => void;
+}>();
+
+const emitPageChange = (page: number) => {
+    if (page !== props.meta.current_page) {
+        props.onPageChange(page);
+    }
+};
+
+// Generate visible page numbers (max 5 around current)
+const pages = computed(() => {
+    const total = props.meta.last_page;
+    const current = props.meta.current_page;
+    const delta = 2; // how many pages before/after current to show
+    const range = [];
+
+    for (let i = Math.max(1, current - delta); i <= Math.min(total, current + delta); i++) {
+        range.push(i);
+    }
+
+    if (range[0] > 2) range.unshift("…");
+    if (range[0] !== 1) range.unshift(1);
+    if (Number(range[range.length - 1]) < total - 1) range.push("…");
+    if (range[range.length - 1] !== total) range.push(total);
+
+    return range;
+});
+</script>
+
+<template>
+    <div v-if="meta" class="flex items-center justify-center mt-10 flex-wrap gap-2 sm:gap-3 text-sm md:text-base">
+        <!-- Prev Button -->
+        <button class="px-4 py-2 btn btn-primary disabled:opacity-40 disabled:cursor-not-allowed transition"
+            :disabled="meta.current_page === 1" @click="emitPageChange(meta.current_page - 1)">
+            <StepBackIcon class="w-4 h-4" />
+        </button>
+
+        <!-- Numbered pages -->
+        <template v-for="(p, i) in pages" :key="i">
+            <button v-if="p !== '…'" class="w-9 h-9 md:w-10 md:h-10 rounded-full border flex items-center justify-center transition
+          hover:bg-blue-50 hover:text-blue-600" :class="{
+            'bg-blue-600 text-white border-blue-600': meta.current_page === p,
+            'border-gray-300 text-gray-700': meta.current_page !== p,
+        }" @click="emitPageChange(p as number)">
+                {{ p }}
+            </button>
+            <span v-else class="px-2 text-gray-400 select-none">…</span>
+        </template>
+
+        <!-- Next Button -->
+        <button class="px-4 py-2 btn btn-primary disabled:opacity-40 disabled:cursor-not-allowed transition"
+            :disabled="meta.current_page === meta.last_page" @click="emitPageChange(meta.current_page + 1)">
+            <StepForwardIcon class="w-4 h-4" />
+        </button>
+    </div>
+</template>
+
+<style scoped>
+button {
+    font-weight: 500;
+}
+</style>

--- a/src/components/ui/AppSidebarMenuList.vue
+++ b/src/components/ui/AppSidebarMenuList.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import type {SidebarMenuConfigType} from "@/config/sidebar-menu.config.ts";
-
-const {name, icon, path, hasSubMenu, subMenu} = defineProps<SidebarMenuConfigType>();
+import type { SidebarMenuConfigType } from "@/config/sidebar-menu.config.ts";
+import { useRoute } from "vue-router";
+const route = useRoute();
+const { name, icon, path, hasSubMenu, subMenu } = defineProps<SidebarMenuConfigType>();
 </script>
 
 <template>
@@ -12,23 +13,17 @@ const {name, icon, path, hasSubMenu, subMenu} = defineProps<SidebarMenuConfigTyp
         {{ name }}
       </summary>
       <ul>
-        <AppSidebarMenuList
-            v-for="(item, index) in subMenu"
-            :key="index"
-            v-bind="item"
-        />
+        <AppSidebarMenuList v-for="(item, index) in subMenu" :key="index" v-bind="item" />
       </ul>
     </details>
   </li>
 
   <li v-else>
-    <RouterLink :to="path ||''" :class="{'menu-active': name==='Dashboard'}">
+    <RouterLink :to="path || ''" :class="{ 'menu-active': route.path === path }">
       <component :is="icon" />
       {{ name }}
     </RouterLink>
   </li>
 </template>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/src/components/ui/FormInput.vue
+++ b/src/components/ui/FormInput.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 
-import {computed, ref} from 'vue';
-import type {FormInputType} from "@/types/form-input.ts";
+import { computed, ref } from 'vue';
+import type { FormInputType } from "@/types/form-input.ts";
 import ShowPasswordButton from "@/components/ui/ShowPasswordButton.vue";
 
 const showPassword = ref<boolean>(false);
@@ -12,6 +12,7 @@ const {
   name,
   placeholder,
   error = null,
+  modelValue
 } = defineProps<FormInputType>();
 
 
@@ -19,6 +20,9 @@ const inputClasses = computed(() => [
   'transition-colors duration-200',
   kind === 'password' ? 'pr-12' : '',
 ]);
+
+
+const emit = defineEmits(["update:modelValue"]);
 
 const convertType = computed<string>(() => {
   if (kind === 'password') {
@@ -37,19 +41,11 @@ const convertType = computed<string>(() => {
     </label>
 
     <div class="relative w-full">
-      <input
-          :type="convertType"
-          :name="name"
-          :placeholder="placeholder"
-          class="input input-md lg:input-lg xl:input-xl w-full"
-          :class="inputClasses"
-      />
+      <input :type="convertType" :name="name" :placeholder="placeholder"
+        class="input input-md lg:input-lg xl:input-xl w-full" :class="inputClasses" :value="modelValue" />
 
       <div v-if="kind === 'password'" class="absolute right-0 top-1/2 -translate-y-1/2 z-10 px-4">
-        <ShowPasswordButton
-            v-if="kind === 'password'"
-            v-model:showPassword="showPassword"
-        />
+        <ShowPasswordButton v-if="kind === 'password'" v-model:showPassword="showPassword" />
       </div>
     </div>
 

--- a/src/components/ui/LogoutButton.vue
+++ b/src/components/ui/LogoutButton.vue
@@ -1,10 +1,19 @@
 <script setup lang="ts">
 
-import {useLogout} from "@/composables/useLogout.ts";
-import AppToast from "@/components/ui/AppToast.vue";
+import { useLogout } from "@/composables/useLogout.ts";
+import { watch } from "vue";
+import { toast } from "vue-sonner";
 
-const {handleLogout, hasError, message, isLoading} = useLogout();
+const { handleLogout, hasError, message, isLoading } = useLogout();
+watch([message, hasError], () => {
+  if (!message.value) return;
 
+  if (hasError.value) {
+    toast.error(message.value);
+  } else {
+    toast.success(message.value);
+  }
+});
 </script>
 
 <template>
@@ -16,7 +25,5 @@ const {handleLogout, hasError, message, isLoading} = useLogout();
       Logout
     </span>
   </button>
-
-  <AppToast :message="message" :isError="hasError"/>
 
 </template>

--- a/src/components/ui/ThemeToggler.vue
+++ b/src/components/ui/ThemeToggler.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import {ref, onMounted, computed} from 'vue'
-import {Sun, Moon, Monitor, type LucideIcon} from 'lucide-vue-next'
+import { ref, onMounted, computed } from 'vue'
+import { Sun, Moon, Monitor, type LucideIcon } from 'lucide-vue-next'
 
 type Theme = 'light' | 'dark';
 type ThemeMode = 'system' | Theme;
@@ -10,9 +10,9 @@ const selectedTheme = ref<ThemeMode>('system')
 const currentTheme = ref<Theme>('light')
 
 const themeItems = ref<ThemeItem[]>([
-  {name: "light", icon: Sun},
-  {name: "dark", icon: Moon},
-  {name: "system", icon: Monitor}
+  { name: "light", icon: Sun },
+  { name: "dark", icon: Moon },
+  { name: "system", icon: Monitor }
 ])
 
 const activeTheme = computed<ThemeItem | undefined>(() => themeItems.value.find(item => item.name === selectedTheme.value));
@@ -69,19 +69,14 @@ onMounted(() => {
       </div>
     </div>
 
-    <ul
-        tabindex="-1"
-        class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow-2xl border border-base-300 w-max"
-    >
-      <li v-for="({name, icon}, index) in themeItems" :key="index">
-        <button
-            @click="setTheme(name)"
-            class="flex items-center gap-3 p-3"
-            :class="{ 'bg-base-200': selectedTheme === name }"
-        >
+    <ul tabindex="-1"
+      class="dropdown-content menu bg-base-100 rounded-box z-10 w-52 p-2 shadow-2xl border border-base-300 w-max">
+      <li v-for="({ name, icon }, index) in themeItems" :key="index">
+        <button @click="setTheme(name)" class="flex items-center gap-3 p-3"
+          :class="{ 'bg-base-200': selectedTheme === name }">
           <component :is="icon" />
           <div class="flex-1 text-left">
-            <div class="font-medium">{{ name.charAt(0).toUpperCase()+""+name.slice(1) }}</div>
+            <div class="font-medium">{{ name.charAt(0).toUpperCase() + "" + name.slice(1) }}</div>
           </div>
           <div v-if="selectedTheme === name" class="w-2 h-2 bg-primary rounded-full"></div>
         </button>
@@ -89,4 +84,3 @@ onMounted(() => {
     </ul>
   </div>
 </template>
-

--- a/src/components/ui/VariantTypeList.vue
+++ b/src/components/ui/VariantTypeList.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue';
 import { CheckCircle2Icon, ChevronDown, CircleAlertIcon, Edit2Icon, PlusCircleIcon, Trash2Icon, TrendingUpDown, XIcon } from 'lucide-vue-next';
 import type { VariantTypeItem } from '@/types/variant-type-response';
 import { VariantsTypeService } from '@/services/VariantsTypeService';
+import { toast } from 'vue-sonner';
 
 const { name, slug, id, values } = defineProps<VariantTypeItem>();
 const emit = defineEmits<{ variantChanged: [] }>();
@@ -13,9 +14,6 @@ const variantValueInput = ref<string>("");
 const variantValuesArray = ref<string[]>([]);
 
 const deleteVariantModal = ref<HTMLDialogElement | null>(null);
-
-console.log(deleteVariantModal);
-
 
 const addVariantValue = () => {
     const trimmed = variantValueInput.value.trim();
@@ -43,14 +41,16 @@ const toggleAccordion = () => {
 const toggleAddVariant = () => {
     addNewVariantTypeValue.value = !addNewVariantTypeValue.value
 }
+
 const saveNewVariantValues = async () => {
     isLoading.value = true;
     const addVariantValue = await VariantsTypeService.addValueToVariantType(slug, variantValuesArray.value);
     if (addVariantValue[0].success) {
         isLoading.value = false;
+        toast.success("Variant Values Added Successfully")
+        variantValuesArray.value = [];
+        addNewVariantTypeValue.value = false;
         emit('variantChanged');
-    } else {
-
     }
 }
 
@@ -58,14 +58,15 @@ const handleDeleteVariantType = async () => {
     isLoading.value = true;
     const res = await VariantsTypeService.deleteVariantType(slug);
     isLoading.value = false;
+    toast.success("Variant Type Deleted Successfully")
     emit('variantChanged');
 };
-
 
 const handleDeleteValue = async (valueSlug: string) => {
     isLoading.value = true;
     const removeVariantValue = await VariantsTypeService.deleteValueFromVariantType(slug, valueSlug)
     isLoading.value = false;
+    toast.success("Variant Type Value Deleted Successfully")
     emit('variantChanged');
 }
 
@@ -76,11 +77,11 @@ const handlePlusCLick = () => {
         toggleAddVariant()
     }
 }
-
 </script>
 
 <template>
-    <div class="relative group w-full">
+    <!-- Responsive card width: full on mobile, half on large screens when closed, full when open -->
+    <div class="relative group w-full" :class="{ 'lg:col-span-2': isOpen }">
         <div class="relative collapse bg-base-100 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 border border-base-300"
             :class="{ 'collapse-open': isOpen }">
 
@@ -115,25 +116,25 @@ const handlePlusCLick = () => {
             <div class="collapse-content" v-show="isOpen">
                 <div class="w-full h-px bg-gradient-to-r from-transparent via-base-300 to-transparent mb-4"></div>
 
-                <div class="flex flex-wrap gap-6 pb-2">
+                <!-- Changed: Better responsive grid layout that works with many items -->
+                <div class="flex flex-wrap gap-3 pb-2">
                     <div v-for="value in values" :key="value.id"
-                        class="flex items-center gap-2 px-3 py-1 bg-base-200 border border-base-300 rounded-full hover:border-primary hover:bg-primary/10 transition">
-                        <span class="text-md font-medium text-base-content/80">
+                        class="flex items-center gap-2 px-3 py-1.5 bg-base-200 border border-base-300 rounded-full hover:border-primary hover:bg-primary/10 transition group/item">
+                        <span class="text-sm font-medium text-base-content/80">
                             {{ value.name }}
                         </span>
-                        <div class="flex items-center gap-1 transition-opacity">
+                        <div class="flex items-center gap-1 opacity-0 group-hover/item:opacity-100 transition-opacity">
                             <button @click="" class="hover:text-primary">
-                                <Edit2Icon class="w-4 h-4" />
+                                <Edit2Icon class="w-3.5 h-3.5" />
                             </button>
                             <button @click="handleDeleteValue(value.slug)" class="hover:text-red-500 cursor-pointer">
-                                <Trash2Icon class="w-4 h-4" />
+                                <Trash2Icon class="w-3.5 h-3.5" />
                             </button>
                         </div>
                     </div>
 
-
                     <!-- Variant Values Input -->
-                    <div v-if="addNewVariantTypeValue">
+                    <div v-if="addNewVariantTypeValue" class="w-full md:w-auto md:min-w-[300px]">
                         <div
                             class="flex flex-wrap items-center gap-2 p-2 border rounded-lg focus-within:ring-2 ring-primary/50">
                             <!-- Pills -->
@@ -149,21 +150,21 @@ const handlePlusCLick = () => {
 
                             <!-- Input -->
                             <input v-model="variantValueInput" @keydown="handleKeydown" type="text"
-                                class="flex-1 outline-none p-1 bg-transparent text-sm"
+                                class="flex-1 min-w-[200px] outline-none p-1 bg-transparent text-sm"
                                 placeholder="Type and press Enter, Tab or comma" />
                         </div>
                     </div>
 
                     <button @click="handlePlusCLick"
-                        class="w-11 h-11 rounded-lg cursor-pointer bg-primary/35 flex items-center justify-center transition-all duration-300 disabled:opacity-20"
+                        class="w-10 h-10 rounded-lg cursor-pointer bg-primary/35 flex items-center justify-center transition-all duration-300 disabled:opacity-20 hover:bg-primary/50"
                         :disabled="isLoading">
-                        <span v-if="isLoading" class="loading loading-bars loading-md lg:loading-lg">
+                        <span v-if="isLoading" class="loading loading-bars loading-sm">
                         </span>
-                        <CheckCircle2Icon class="w-7 h-7 transition-all duration-300 text-base-content/70"
+                        <CheckCircle2Icon class="w-5 h-5 transition-all duration-300 text-base-content/70"
                             v-else-if="addNewVariantTypeValue && variantValuesArray.length > 0" />
-                        <XIcon class="w-7 h-7 transition-all duration-300 text-base-content/70"
+                        <XIcon class="w-5 h-5 transition-all duration-300 text-base-content/70"
                             v-else-if="addNewVariantTypeValue" />
-                        <PlusCircleIcon class="w-7 h-7 transition-all duration-300 text-base-content/70" v-else />
+                        <PlusCircleIcon class="w-5 h-5 transition-all duration-300 text-base-content/70" v-else />
                     </button>
                 </div>
             </div>
@@ -173,7 +174,7 @@ const handlePlusCLick = () => {
     <dialog ref="deleteVariantModal" id="deleteVariantModal" class="modal">
         <div class="modal-box w-full max-w-lg">
             <CircleAlertIcon class="w-12 h-12 text-red-600 mx-auto mb-4" />
-            <h2 class="text-lg font-semibold uppercase mb-4 text-center">Are you sure you want to delete {{ name }}??
+            <h2 class="text-lg font-semibold uppercase mb-4 text-center">Are you sure you want to delete {{ name }}?
             </h2>
             <!-- Actions -->
             <div class="modal-action mt-6 flex justify-end gap-3">
@@ -181,7 +182,7 @@ const handlePlusCLick = () => {
                     <button class="btn btn-outline">Cancel</button>
                 </form>
                 <button type="button" @click="handleDeleteVariantType" class="btn btn-primary" :disabled="isLoading">
-                    <span v-if="isLoading" class="loading loading-bars loading-md lg:loading-lg">
+                    <span v-if="isLoading" class="loading loading-bars loading-md">
                     </span>
                     <span v-else>
                         Delete Variant Type
@@ -195,7 +196,6 @@ const handlePlusCLick = () => {
             <button>Close</button>
         </form>
     </dialog>
-
 </template>
 
 <style scoped>

--- a/src/components/ui/VariantTypeList.vue
+++ b/src/components/ui/VariantTypeList.vue
@@ -1,0 +1,227 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { CheckCircle2Icon, ChevronDown, CircleAlertIcon, Edit2Icon, PlusCircleIcon, Trash2Icon, TrendingUpDown, XIcon } from 'lucide-vue-next';
+import type { VariantTypeItem } from '@/types/variant-type-response';
+import { VariantsTypeService } from '@/services/VariantsTypeService';
+
+const { name, slug, id, values } = defineProps<VariantTypeItem>();
+const emit = defineEmits<{ variantChanged: [] }>();
+const isOpen = ref(false);
+const addNewVariantTypeValue = ref(false)
+const isLoading = ref(false)
+const variantValueInput = ref<string>("");
+const variantValuesArray = ref<string[]>([]);
+
+const deleteVariantModal = ref<HTMLDialogElement | null>(null);
+
+console.log(deleteVariantModal);
+
+
+const addVariantValue = () => {
+    const trimmed = variantValueInput.value.trim();
+    if (trimmed && !variantValuesArray.value.includes(trimmed)) {
+        variantValuesArray.value.push(trimmed);
+    }
+    variantValueInput.value = "";
+};
+
+const handleKeydown = (e: KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === "," || e.key === "Tab") {
+        e.preventDefault();
+        addVariantValue();
+    }
+};
+
+const removeVariantValue = (value: string) => {
+    variantValuesArray.value = variantValuesArray.value.filter(v => v !== value);
+};
+
+const toggleAccordion = () => {
+    isOpen.value = !isOpen.value;
+};
+
+const toggleAddVariant = () => {
+    addNewVariantTypeValue.value = !addNewVariantTypeValue.value
+}
+const saveNewVariantValues = async () => {
+    isLoading.value = true;
+    const addVariantValue = await VariantsTypeService.addValueToVariantType(slug, variantValuesArray.value);
+    if (addVariantValue[0].success) {
+        isLoading.value = false;
+        emit('variantChanged');
+    } else {
+
+    }
+}
+
+const handleDeleteVariantType = async () => {
+    isLoading.value = true;
+    const res = await VariantsTypeService.deleteVariantType(slug);
+    isLoading.value = false;
+    emit('variantChanged');
+};
+
+
+const handleDeleteValue = async (valueSlug: string) => {
+    isLoading.value = true;
+    const removeVariantValue = await VariantsTypeService.deleteValueFromVariantType(slug, valueSlug)
+    isLoading.value = false;
+    emit('variantChanged');
+}
+
+const handlePlusCLick = () => {
+    if (addNewVariantTypeValue && variantValuesArray.value.length > 0) {
+        saveNewVariantValues()
+    } else {
+        toggleAddVariant()
+    }
+}
+
+</script>
+
+<template>
+    <div class="relative group w-full">
+        <div class="relative collapse bg-base-100 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 border border-base-300"
+            :class="{ 'collapse-open': isOpen }">
+
+            <div class="collapse-title cursor-pointer" @click="toggleAccordion">
+                <div class="flex items-center justify-between">
+                    <div class="flex items-center gap-3">
+                        <div
+                            class="w-10 h-10 rounded-xl bg-primary flex items-center justify-center shadow-md transform transition-transform duration-300 group-hover:scale-110 group-hover:rotate-3">
+                            <TrendingUpDown class="w-5 h-5 text-primary-content" />
+                        </div>
+                        <div>
+                            <h3 class="text-lg font-bold text-base-content tracking-tight">{{ name }}</h3>
+                            <p class="text-xs text-base-content/60 mt-0.5">{{ values?.length || 0 }} options available
+                            </p>
+                        </div>
+                    </div>
+                    <div class="flex items-center gap-2">
+                        <div class="w-8 h-8 rounded-lg bg-base-200 flex items-center justify-center transition-all duration-300"
+                            :class="{ 'bg-primary/20': isOpen }">
+                            <ChevronDown
+                                :class="['w-5 h-5 transition-all duration-300 text-base-content/70', { 'rotate-180 !text-primary': isOpen }]" />
+                        </div>
+                        <button
+                            class="w-8 h-8 rounded-lg bg-red-100 opacity-0 group-hover:opacity-100 hover:bg-red-200 flex items-center justify-center transition cursor-pointer"
+                            @click.stop="deleteVariantModal?.showModal()">
+                            <Trash2Icon class="w-4 h-4 text-red-600" />
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <div class="collapse-content" v-show="isOpen">
+                <div class="w-full h-px bg-gradient-to-r from-transparent via-base-300 to-transparent mb-4"></div>
+
+                <div class="flex flex-wrap gap-6 pb-2">
+                    <div v-for="value in values" :key="value.id"
+                        class="flex items-center gap-2 px-3 py-1 bg-base-200 border border-base-300 rounded-full hover:border-primary hover:bg-primary/10 transition">
+                        <span class="text-md font-medium text-base-content/80">
+                            {{ value.name }}
+                        </span>
+                        <div class="flex items-center gap-1 transition-opacity">
+                            <button @click="" class="hover:text-primary">
+                                <Edit2Icon class="w-4 h-4" />
+                            </button>
+                            <button @click="handleDeleteValue(value.slug)" class="hover:text-red-500 cursor-pointer">
+                                <Trash2Icon class="w-4 h-4" />
+                            </button>
+                        </div>
+                    </div>
+
+
+                    <!-- Variant Values Input -->
+                    <div v-if="addNewVariantTypeValue">
+                        <div
+                            class="flex flex-wrap items-center gap-2 p-2 border rounded-lg focus-within:ring-2 ring-primary/50">
+                            <!-- Pills -->
+                            <span v-for="(value, i) in variantValuesArray" :key="i"
+                                class="px-3 py-1 bg-primary/10 text-primary text-sm font-medium rounded-full flex items-center gap-2">
+                                {{ value }}
+                                <button type="button"
+                                    class="text-primary hover:text-red-500 focus:outline-none cursor-pointer"
+                                    @click="removeVariantValue(value)">
+                                    ×
+                                </button>
+                            </span>
+
+                            <!-- Input -->
+                            <input v-model="variantValueInput" @keydown="handleKeydown" type="text"
+                                class="flex-1 outline-none p-1 bg-transparent text-sm"
+                                placeholder="Type and press Enter, Tab or comma" />
+                        </div>
+                    </div>
+
+                    <button @click="handlePlusCLick"
+                        class="w-11 h-11 rounded-lg cursor-pointer bg-primary/35 flex items-center justify-center transition-all duration-300 disabled:opacity-20"
+                        :disabled="isLoading">
+                        <span v-if="isLoading" class="loading loading-bars loading-md lg:loading-lg">
+                        </span>
+                        <CheckCircle2Icon class="w-7 h-7 transition-all duration-300 text-base-content/70"
+                            v-else-if="addNewVariantTypeValue && variantValuesArray.length > 0" />
+                        <XIcon class="w-7 h-7 transition-all duration-300 text-base-content/70"
+                            v-else-if="addNewVariantTypeValue" />
+                        <PlusCircleIcon class="w-7 h-7 transition-all duration-300 text-base-content/70" v-else />
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <dialog ref="deleteVariantModal" id="deleteVariantModal" class="modal">
+        <div class="modal-box w-full max-w-lg">
+            <CircleAlertIcon class="w-12 h-12 text-red-600 mx-auto mb-4" />
+            <h2 class="text-lg font-semibold uppercase mb-4 text-center">Are you sure you want to delete {{ name }}??
+            </h2>
+            <!-- Actions -->
+            <div class="modal-action mt-6 flex justify-end gap-3">
+                <form method="dialog">
+                    <button class="btn btn-outline">Cancel</button>
+                </form>
+                <button type="button" @click="handleDeleteVariantType" class="btn btn-primary" :disabled="isLoading">
+                    <span v-if="isLoading" class="loading loading-bars loading-md lg:loading-lg">
+                    </span>
+                    <span v-else>
+                        Delete Variant Type
+                    </span>
+                </button>
+            </div>
+        </div>
+
+        <!-- Click outside to close -->
+        <form method="dialog" class="modal-backdrop">
+            <button>Close</button>
+        </form>
+    </dialog>
+
+</template>
+
+<style scoped>
+.collapse-title::after {
+    display: none;
+}
+
+.collapse-content {
+    scrollbar-width: thin;
+    scrollbar-color: oklch(var(--p) / 0.3) transparent;
+}
+
+.collapse-content::-webkit-scrollbar {
+    width: 6px;
+}
+
+.collapse-content::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.collapse-content::-webkit-scrollbar-thumb {
+    background-color: oklch(var(--p) / 0.3);
+    border-radius: 3px;
+}
+
+.collapse-content::-webkit-scrollbar-thumb:hover {
+    background-color: oklch(var(--p) / 0.5);
+}
+</style>

--- a/src/components/ui/preloaders/VariantsSkeleton.vue
+++ b/src/components/ui/preloaders/VariantsSkeleton.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+defineProps<{
+    count?: number;
+}>();
+</script>
+
+<template>
+    <div v-for="i in (count || 5)" :key="i" class="relative group w-full">
+        <div class="relative bg-base-100 rounded-2xl shadow-lg border border-base-300 p-4 animate-pulse">
+            <div class="flex items-center justify-between">
+                <div class="flex items-center gap-3 flex-1">
+                    <!-- Icon skeleton -->
+                    <div class="w-10 h-10 rounded-xl bg-base-300"></div>
+
+                    <div class="flex-1">
+                        <!-- Title skeleton -->
+                        <div class="h-5 bg-base-300 rounded w-32 mb-2"></div>
+                        <!-- Subtitle skeleton -->
+                        <div class="h-3 bg-base-300 rounded w-24"></div>
+                    </div>
+                </div>
+
+                <!-- Chevron skeleton -->
+                <div class="w-8 h-8 rounded-lg bg-base-300"></div>
+            </div>
+        </div>
+    </div>
+</template>

--- a/src/config/sidebar-menu.config.ts
+++ b/src/config/sidebar-menu.config.ts
@@ -1,97 +1,97 @@
 import {
-    Boxes,
-    CirclePercent,
-    LayoutDashboard,
-    type LucideIcon,
-    PackageSearch,
-    SquareActivity,
-    TrendingUpDown,
-    User,
-    UsersRound,
-    ShieldCheck,
-    Briefcase,
-    PlusCircle,
-    List
+  Boxes,
+  CirclePercent,
+  LayoutDashboard,
+  type LucideIcon,
+  PackageSearch,
+  SquareActivity,
+  TrendingUpDown,
+  User,
+  UsersRound,
+  ShieldCheck,
+  Briefcase,
+  PlusCircle,
+  List,
 } from "lucide-vue-next";
 
 export type SidebarMenuConfigType = {
-    name: string;
-    icon: LucideIcon;
-    path?: string;
-    hasSubMenu?: boolean;
-    subMenu?: SidebarMenuConfigType[];
+  name: string;
+  icon: LucideIcon;
+  path?: string;
+  hasSubMenu?: boolean;
+  subMenu?: SidebarMenuConfigType[];
 };
 
 export const sidebarMenuConfig: SidebarMenuConfigType[] = [
-    {
-        name: "Dashboard",
-        icon: LayoutDashboard,
+  {
+    name: "Dashboard",
+    icon: LayoutDashboard,
+    path: "/app/dashboard",
+  },
+  {
+    name: "Variants",
+    icon: TrendingUpDown,
+    path: "/app/variant-types",
+  },
+  {
+    name: "Categories",
+    icon: Boxes,
+    path: "",
+  },
+  {
+    name: "Products",
+    icon: PackageSearch,
+    hasSubMenu: true,
+    subMenu: [
+      {
+        name: "Add Product",
         path: "",
-    },
-    {
-        name: "Variants",
-        icon: TrendingUpDown,
+        icon: PlusCircle,
+      },
+      {
+        name: "View Products",
         path: "",
-    },
-    {
-        name: "Categories",
-        icon: Boxes,
+        icon: List,
+      },
+    ],
+  },
+  {
+    name: "Inventory",
+    icon: SquareActivity,
+    hasSubMenu: true,
+    subMenu: [
+      {
+        name: "Inventory Overview",
         path: "",
-    },
-    {
-        name: "Products",
-        icon: PackageSearch,
-        hasSubMenu: true,
-        subMenu: [
-            {
-                name: "Add Product",
-                path: "",
-                icon: PlusCircle,
-            },
-            {
-                name: "View Products",
-                path: "",
-                icon: List,
-            }
-        ]
-    },
-    {
-        name: "Inventory",
         icon: SquareActivity,
-        hasSubMenu: true,
-        subMenu: [
-            {
-                name: "Inventory Overview",
-                path: "",
-                icon: SquareActivity,
-            },
-            {
-                name: "Transfer Stock",
-                path: "",
-                icon: CirclePercent,
-            }
-        ]
-    },
-    {
-        name: "Users",
-        icon: User,
-        hasSubMenu: true,
-        subMenu: [
-            {
-                name: "All Users",
-                path: "",
-                icon: UsersRound,
-            },
-            {
-                name: "Roles",
-                path: "",
-                icon: Briefcase,
-            },
-            {
-                name: "Permissions",
-                path: "",
-                icon: ShieldCheck,
-            }
-        ]
-    },
+      },
+      {
+        name: "Transfer Stock",
+        path: "",
+        icon: CirclePercent,
+      },
+    ],
+  },
+  {
+    name: "Users",
+    icon: User,
+    hasSubMenu: true,
+    subMenu: [
+      {
+        name: "All Users",
+        path: "",
+        icon: UsersRound,
+      },
+      {
+        name: "Roles",
+        path: "",
+        icon: Briefcase,
+      },
+      {
+        name: "Permissions",
+        path: "",
+        icon: ShieldCheck,
+      },
+    ],
+  },
 ];

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,17 +1,18 @@
-import '@/assets/style/main.css'
-import piniaPluginPersistedState from 'pinia-plugin-persistedstate'
+import "@/assets/style/main.css";
+import piniaPluginPersistedState from "pinia-plugin-persistedstate";
 
-import { createApp } from 'vue'
-import { createPinia } from 'pinia'
+import { createApp } from "vue";
+import { createPinia } from "pinia";
 
-import App from './App.vue'
-import router from './router'
+import App from "./App.vue";
+import router from "./router";
 
 const app = createApp(App);
 const pinia = createPinia();
 
-pinia.use(piniaPluginPersistedState)
-app.use(pinia)
-app.use(router)
+pinia.use(piniaPluginPersistedState);
+app.use(pinia);
+app.use(router);
+import "vue-sonner/style.css";
 
-app.mount('#app')
+app.mount("#app");

--- a/src/router/app-route.ts
+++ b/src/router/app-route.ts
@@ -1,19 +1,28 @@
 import AppLayout from "@/layouts/AppLayout.vue";
 import DashboardView from "@/views/app/DashboardView.vue";
-import type {RouteRecordRaw} from "vue-router";
+import VariantsView from "@/views/app/VariantsTypeView.vue";
+import type { RouteRecordRaw } from "vue-router";
 
 export const appRouter: RouteRecordRaw = {
-    path: "/app",
-    component: AppLayout,
-    redirect: "/app/dashboard",
-    children: [
-        {
-            path: "dashboard",
-            name: "Dashboard",
-            component: DashboardView,
-            meta: {
-             requiresAuth: true,
-            }
-        },
-    ],
+  path: "/app",
+  component: AppLayout,
+  redirect: "/app/dashboard",
+  children: [
+    {
+      path: "dashboard",
+      name: "Dashboard",
+      component: DashboardView,
+      meta: {
+        requiresAuth: true,
+      },
+    },
+    {
+      path: "variant-types",
+      name: "Variants",
+      component: VariantsView,
+      meta: {
+        requiresAuth: true,
+      },
+    },
+  ],
 };

--- a/src/services/VariantsTypeService.ts
+++ b/src/services/VariantsTypeService.ts
@@ -1,0 +1,186 @@
+import type {
+  VariantTypeResponse,
+  VariantTypeResponseDto,
+} from "@/types/variant-type-response";
+import { ApiService } from "./ApiService";
+import { ApiError } from "./error/api-error";
+
+export class VariantsTypeService {
+  public static async createVariantType(
+    name: string,
+    values: string[]
+  ): Promise<VariantTypeResponseDto> {
+    try {
+      const response = await ApiService.post<VariantTypeResponse>(
+        "/variant-types",
+        {
+          name,
+          values,
+        }
+      );
+      if (response.success) {
+        return [
+          {
+            success: true,
+            message: response.message,
+          },
+        ];
+      }
+      return [
+        {
+          success: false,
+          message: response.message ?? "Failed to create variant",
+        },
+      ];
+    } catch (e: any) {
+      return [
+        {
+          success: false,
+          message: e.message ?? "Failed to create variant",
+        },
+      ];
+    }
+  }
+
+  public static async getVariantsType(
+    perPage = 10,
+    page = 1
+  ): Promise<VariantTypeResponseDto> {
+    try {
+      const variants = await ApiService.get<VariantTypeResponse>(
+        `/variant-types?row=${perPage}&page=${page}`,
+        {
+          credentials: "include",
+        }
+      );
+      if (variants.success) {
+        return [
+          {
+            success: true,
+            message: variants.message,
+            data: variants.data.data,
+            links: variants.data.links,
+            meta: variants.data.meta,
+          },
+        ];
+      }
+      return [
+        {
+          success: false,
+          message: variants.message ?? "Failed to get variants",
+        },
+      ];
+    } catch (e: any) {
+      return [
+        {
+          success: false,
+          message: e.message ?? "Failed to get variants",
+        },
+      ];
+    }
+  }
+
+  public static async addValueToVariantType(
+    slug: string,
+    values: string[]
+  ): Promise<VariantTypeResponseDto> {
+    try {
+      const response = await ApiService.post<VariantTypeResponse>(
+        `/variant-types/${slug}`,
+        {
+          values,
+        }
+      );
+      if (response.success) {
+        return [
+          {
+            success: true,
+            message: response.message,
+          },
+        ];
+      }
+      return [
+        {
+          success: false,
+          message: response.message ?? "Failed to add values to variant type",
+        },
+      ];
+    } catch (e: any) {
+      return [
+        {
+          success: false,
+          message: e.message ?? "Failed to add values to variant type",
+        },
+      ];
+    }
+  }
+  public static async deleteValueFromVariantType(
+    slug: string,
+    valueSlug: string
+  ): Promise<VariantTypeResponseDto> {
+    try {
+      const response = await ApiService.delete<VariantTypeResponse>(
+        `/variant-types/${slug}/${valueSlug}`,
+        {
+          credentials: "include",
+        }
+      );
+      if (response.success) {
+        return [
+          {
+            success: true,
+            message: response.message,
+          },
+        ];
+      }
+      return [
+        {
+          success: false,
+          message:
+            response.message ?? "Failed to delete value from variant type",
+        },
+      ];
+    } catch (e: any) {
+      return [
+        {
+          success: false,
+          message: e.message ?? "Failed to delete value from variant type",
+        },
+      ];
+    }
+  }
+  public static async deleteVariantType(
+    slug: string
+  ): Promise<VariantTypeResponseDto> {
+    try {
+      const response = await ApiService.delete<VariantTypeResponse>(
+        `/variant-types/${slug}`,
+        {
+          credentials: "include",
+        }
+      );
+      if (response.success) {
+        return [
+          {
+            success: true,
+            message: response.message,
+          },
+        ];
+      }
+      return [
+        {
+          success: false,
+          message:
+            response.message ?? "Failed to delete value from variant type",
+        },
+      ];
+    } catch (e: any) {
+      return [
+        {
+          success: false,
+          message: e.message ?? "Failed to delete value from variant type",
+        },
+      ];
+    }
+  }
+}

--- a/src/services/error/api-error.ts
+++ b/src/services/error/api-error.ts
@@ -1,14 +1,13 @@
-
 export class ApiError extends Error {
-    public statusCode: number;
-    public responseBody: any;
+  public statusCode: number;
+  public responseBody: any;
 
-    constructor(message: string, statusCode?: number, responseBody?: any) {
-        super(message);
-        this.name = 'ApiError';
-        this.statusCode = statusCode;
-        this.responseBody = responseBody;
+  constructor(message: string, statusCode?: number, responseBody?: any) {
+    super(message);
+    this.name = "ApiError";
+    this.statusCode = statusCode ?? 500;
+    this.responseBody = responseBody;
 
-        Object.setPrototypeOf(this, ApiError.prototype);
-    }
+    Object.setPrototypeOf(this, ApiError.prototype);
+  }
 }

--- a/src/types/form-input.ts
+++ b/src/types/form-input.ts
@@ -1,8 +1,9 @@
 export type FormInputType = {
-    name: string;
-    kind: string;
-    type: string;
-    placeholder: string;
-    label?: string;
-    error?: string;
+  name: string;
+  kind: string;
+  type: string;
+  placeholder: string;
+  label?: string;
+  error?: string;
+  modelValue?: any;
 };

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -1,0 +1,24 @@
+export interface PaginationLink {
+  url: string | null;
+  label: string;
+  page: number | null;
+  active: boolean;
+}
+
+export interface PaginationMeta {
+  current_page: number;
+  from: number;
+  last_page: number;
+  links: PaginationLink[];
+  path: string;
+  per_page: number;
+  to: number;
+  total: number;
+}
+
+export interface PaginationLinks {
+  first: string;
+  last: string;
+  prev: string | null;
+  next: string | null;
+}

--- a/src/types/variant-type-response.ts
+++ b/src/types/variant-type-response.ts
@@ -1,0 +1,59 @@
+import type { Ref } from "vue";
+import type { APIErrorResponse, APISuccessResponse } from "./api-response";
+
+export type VariantTypeItem = {
+  id: number;
+  name: string;
+  slug: string;
+  values: {
+    id: number;
+    name: string;
+    slug: string;
+  }[];
+};
+
+export type VariantTypePaginationMeta = {
+  current_page: number;
+  from: number;
+  last_page: number;
+  per_page: number;
+  to: number;
+  total: number;
+  links: {
+    url: string | null;
+    label: string;
+    active: boolean;
+  }[];
+};
+
+export type VariantTypePaginationLinks = {
+  first: string | null;
+  last: string | null;
+  prev: string | null;
+  next: string | null;
+};
+
+export type VariantTypeSuccessResponse = APISuccessResponse & {
+  data: {
+    data: VariantTypeItem[];
+    links: VariantTypePaginationLinks;
+    meta: VariantTypePaginationMeta;
+  };
+};
+
+export type VariantTypeErrorResponse = APIErrorResponse & {
+  errors?: any;
+};
+
+export type VariantTypeResponse =
+  | VariantTypeSuccessResponse
+  | VariantTypeErrorResponse;
+
+export type VariantTypeResponseDto = {
+  success: boolean;
+  message: string;
+  data?: VariantTypeItem[];
+  meta?: VariantTypePaginationMeta;
+  links?: VariantTypePaginationLinks;
+  errors?: any;
+}[];

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -4,11 +4,22 @@ import type { FormInputType } from "@/types/form-input.ts";
 import { loginFormInputs } from "@/config/login-form.config.ts";
 import { useValidationErrors } from "@/composables/useValidationErrors.ts";
 import { useLogin } from "@/composables/useLogin.ts";
-import AppToast from "@/components/ui/AppToast.vue";
+import { toast } from "vue-sonner";
+import { watch } from "vue";
 
 const { isLoading, errors, hasErrors, globalMessage, handleLogin } = useLogin();
 const inputs: FormInputType[] = loginFormInputs;
 const { getErrorMessage } = useValidationErrors(errors);
+
+watch([globalMessage, hasErrors], () => {
+  if (!globalMessage.value) return;
+
+  if (hasErrors.value) {
+    toast.error(globalMessage.value);
+  } else {
+    toast.success(globalMessage.value);
+  }
+});
 </script>
 
 <template>
@@ -53,7 +64,5 @@ const { getErrorMessage } = useValidationErrors(errors);
         </div>
       </form>
     </div>
-
-    <AppToast :message="globalMessage" :isError="hasErrors" />
   </main>
 </template>

--- a/src/views/app/VariantsTypeView.vue
+++ b/src/views/app/VariantsTypeView.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+import AddVariantModal from '@/components/layout/AddVariantTypeModal.vue';
+import AppPagination from '@/components/ui/AppPagination.vue';
+import VariantsSkeleton from '@/components/ui/preloaders/VariantsSkeleton.vue';
+import VariantTypeList from '@/components/ui/VariantTypeList.vue';
+import { VariantsTypeService } from '@/services/VariantsTypeService';
+import type { VariantTypeResponseDto } from '@/types/variant-type-response';
+import { PlusCircle } from 'lucide-vue-next';
+import { onMounted, ref, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+
+const route = useRoute();
+const router = useRouter();
+
+const perPage = ref(Number(route.query.perPage) || 10);
+const row = ref(Number(route.query.row) || 4);
+const page = ref(Number(route.query.page) || 1);
+
+const variants = ref<any[]>([]);
+const pagination = ref<any>(null);
+const loading = ref(false);
+
+const variantChanged = ref(false);
+
+const fetchVariants = async () => {
+    loading.value = true;
+    const response: VariantTypeResponseDto = await VariantsTypeService.getVariantsType(
+        perPage.value,
+        page.value
+    );
+    variants.value = response[0]?.data || [];
+    pagination.value = response[0]?.meta || null;
+    loading.value = false;
+};
+
+onMounted(fetchVariants);
+
+watch(
+    [() => route.query, variantChanged],
+    async ([query, variantChanged]) => {
+        page.value = Number(query.page) || 1;
+        perPage.value = Number(query.perPage) || 10;
+        row.value = Number(query.row) || 4;
+        await fetchVariants();
+    },
+    { deep: true }
+);
+
+const showAddVariantModal = () => {
+    const modal = document.getElementById('addVariantModal') as HTMLDialogElement;
+    modal.showModal();
+};
+
+const goToPage = (newPage: number) => {
+    router.push({
+        query: {
+            ...route.query,
+            page: newPage.toString()
+        },
+    });
+};
+
+const rowsPerPageOptions = [5, 10, 15, 20, 25, 30, 50];
+</script>
+
+<template>
+    <main class="p-4 px-8 md:px-24">
+        <div class="flex items-center justify-between mb-8">
+            <h1 class="text-2xl md:text-4xl">Variants View</h1>
+            <div class="flex items-center justify-end gap-4 flex-wrap">
+                <button class="btn btn-primary" @click="showAddVariantModal">
+                    Add Variant Type
+                    <PlusCircle class="w-5 h-5 ml-2" />
+                </button>
+                <div class="dropdown dropdown-end">
+                    <div tabindex="0" role="button" class="btn m-1">
+                        Rows per page: {{ perPage }}
+                    </div>
+                    <p class="text-xs absolute right-0 text-[#c0c0c0]">Showing {{ variants.length }} rows out of {{
+                        pagination?.total }}</p>
+                    <ul tabindex="0" class="dropdown-content w-full menu p-2 shadow bg-base-100 rounded-box">
+                        <li v-for="option in rowsPerPageOptions" :key="option">
+                            <button @click="
+                                () => {
+                                    perPage = option;
+                                    router.push({
+                                        query: {
+                                            ...route.query,
+                                            perPage: option.toString(),
+                                            page: '1',
+                                        },
+                                    });
+                                }
+                            ">
+                                {{ option }} Rows
+                            </button>
+                        </li>
+                    </ul>
+                </div>
+
+            </div>
+        </div>
+
+        <div class="flex flex-col items-center justify-center gap-4">
+            <VariantsSkeleton v-if="loading" :count="perPage" />
+            <VariantTypeList v-else v-for="variant in variants" :key="variant.id" v-bind="variant"
+                @variantChanged="variantChanged = !variantChanged" />
+        </div>
+        <AppPagination v-if="pagination" :meta="pagination" :onPageChange="goToPage" />
+    </main>
+    <AddVariantModal @variantChanged="variantChanged = !variantChanged" />
+</template>

--- a/src/views/app/VariantsTypeView.vue
+++ b/src/views/app/VariantsTypeView.vue
@@ -101,7 +101,7 @@ const rowsPerPageOptions = [5, 10, 15, 20, 25, 30, 50];
             </div>
         </div>
 
-        <div class="flex flex-col items-center justify-center gap-4">
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 auto-rows-max">
             <VariantsSkeleton v-if="loading" :count="perPage" />
             <VariantTypeList v-else v-for="variant in variants" :key="variant.id" v-bind="variant"
                 @variantChanged="variantChanged = !variantChanged" />


### PR DESCRIPTION
Summary
- Adds a full frontend surface for managing product variant types: listing with pagination, adding new variant types (with multi-value entry), adding values to an existing type, and deleting values / entire variant types. Implements a typed API client and response types used by the new views/components.

Why this change
- Enables admin users to manage variant types (e.g. color, size) from the frontend. Consolidates API interactions for variant-types in a single service and adds UI components to create, list, update and delete variant data.

Key changes (files)
- VariantsTypeView.vue
  - New view that loads variant types, supports rows-per-page and page navigation, shows skeleton while loading, opens add-variant dialog.
- AddVariantTypeModal.vue
  - Modal form for creating variant types and entering multiple values via pills / keyboard separators.
- VariantTypeList.vue
  - Card/accordion for each variant type showing values, add-values UI, delete confirmation modal, inline delete actions per value.
- VariantsTypeService.ts
  - Service methods: getVariantsType, createVariantType, addValueToVariantType, deleteValueFromVariantType, deleteVariantType. Wraps ApiService calls and normalizes responses.
- variant-type-response.ts
  - New TypeScript types describing API responses, pagination meta and DTOs.

API / Back-end expectations
- Endpoints used:
  - GET /variant-types?row={perPage}&page={page} — returns paginated list (data, meta, links).
  - POST /variant-types — create new variant type with { name, values }.
  - POST /variant-types/{slug} — add values to existing variant type.
  - DELETE /variant-types/{slug}/{valueSlug} — remove a value.
  - DELETE /variant-types/{slug} — delete a variant type.
- Response format expected to follow the APISuccessResponse / APIErrorResponse shapes used in types.